### PR TITLE
fix video thumbnails

### DIFF
--- a/resources/gelbooru-overhaul.utils.js
+++ b/resources/gelbooru-overhaul.utils.js
@@ -416,7 +416,7 @@ class utils {
                     let post = json.post[0];
 
                     let fileLink = post.file_url;
-                    let highResThumb = fileLink.startsWith("https://video") ? fileLink.replace(new RegExp(/\.([^\.]+)$/, "gm"), ".jpg") : fileLink;
+                    let highResThumb = fileLink.startsWith("https://video") ? fileLink.replace(new RegExp(/\.([^\.]+)$/, "gm"), ".jpg").replace(/https:\/\/[^\.]+\./, 'https://img3.') : fileLink;
                     let md5 = post.md5;
 
                     if (!highResThumb || !fileLink) throw new Error("Failed to parse url");


### PR DESCRIPTION
Quick and dirty hack to fix the high resolution thumbnails for videos breaking sometime in the last month or two.

![SCR-20231226-h4s](https://github.com/Enchoseon/gelbooru-overhaul-userscript/assets/51227316/1118f720-73fb-402c-b4a0-bbce68e88901)

Simply replaces the video-cdn1 subdomain with img3, which now seems to hold the thumbnail.